### PR TITLE
use replication key instead of created_at

### DIFF
--- a/meltano.yml
+++ b/meltano.yml
@@ -14,7 +14,7 @@ plugins:
     - catalog
     - discover
     config:
-      start_date: '2023-12-08T15:00:00Z'
+      start_date: 1741706134
       access_token: $TAP_INTERCOM_ACCESS_TOKEN
     select:
     - "*.*"

--- a/tap_intercom/client.py
+++ b/tap_intercom/client.py
@@ -76,7 +76,7 @@ class IntercomStream(RESTStream):
                 next page of data.
         """
         if self.rest_method == "POST":
-            body = {"sort": {"field": "updated_at", "order": "ascending"}}
+            body = {"sort": {"field": self.replication_key, "order": "ascending"}}
             start_date = self.get_starting_replication_key_value(context)
             if start_date or self.config.get("filters", {}).get(self.name):
                 body["query"] = {
@@ -89,7 +89,7 @@ class IntercomStream(RESTStream):
                 if start_date:
                     body["query"]["value"].append(
                         {
-                            "field": "created_at",
+                            "field": self.replication_key,
                             "operator": ">",
                             "value": start_date,
                         },


### PR DESCRIPTION
for some reason this was moved to use `created_at` instead of the replication key `updated_at`. this should be reverted.